### PR TITLE
Fix jp-toolbar.positioning-region not filling jp-toolbar size

### DIFF
--- a/packages/components/src/toolbar/toolbar.styles.ts
+++ b/packages/components/src/toolbar/toolbar.styles.ts
@@ -48,6 +48,8 @@ export const toolbarStyles: FoundationElementTemplate<
       display: inline-flex;
       flex-flow: row wrap;
       justify-content: flex-start;
+      width: 100%;
+      height: 100%;
     }
 
     :host([orientation='vertical']) .positioning-region {


### PR DESCRIPTION
Bug seen in JupyterLab when switching the toolbar to use `jp-toolbar`.