### PR TITLE
Sync jp-border-radius with corner-control-radius

### DIFF
--- a/packages/components/src/utilities/theme/applyTheme.ts
+++ b/packages/components/src/utilities/theme/applyTheme.ts
@@ -20,6 +20,7 @@ import {
   accentPalette,
   baseLayerLuminance,
   bodyFont,
+  controlCornerRadius,
   neutralPalette,
   strokeWidth,
   typeRampBaseFontSize
@@ -109,6 +110,10 @@ const tokenMappings: { [key: string]: IConverter<any> } = {
   '--jp-border-width': {
     converter: intConverter,
     token: strokeWidth
+  },
+  '--jp-border-radius': {
+    converter: intConverter,
+    token: controlCornerRadius
   },
   '--jp-layout-color1': {
     converter: (value: string, isDark: boolean): Palette<Swatch> | null => {


### PR DESCRIPTION
This will make the toolkit react to border radius from JupyterLab theme. And by default the radius will be smaller increasing the fit with JupyterLab theme.