### PR TITLE
Try to read Jupyter CSS properties even if body attribute is not set.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ jupyter_ui_demo/labextension
 # Version file is handled by hatchling
 jupyter_ui_demo/_version.py
 
+examples/cdn/toolkit.min.js
+
 # Created by https://www.gitignore.io/api/python
 # Edit at https://www.gitignore.io/?templates=python
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ A pre-bundled script that contains all APIs needed to use Jupyter UI Toolkit is 
 
 The above CDN location points to the latest release of `@jupyter/web-components`. It is advised that when you deploy your site or app, you import the specific version you have developed and tested with.
 
+See the [example](./examples/cdn/index.html) folder for more hints about theming.
+
 ## Documentation
 
 Further documentation can be found in the following places:

--- a/examples/cdn/index.html
+++ b/examples/cdn/index.html
@@ -17,23 +17,52 @@
             --jp-ui-font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
             --jp-ui-font-size1: 13px;
         }
+
+        body {
+            background-color: var(--neutral-layer-1);
+        }
+
+        #theme-mode>span {
+            display: inline-block;
+            width: 24px;
+            height: 24px;
+            background-image: url('https://unpkg.com/@mdi/svg/svg/brightness-6.svg');
+            background-color: var(--neutral-foreground-rest);
+            mix-blend-mode: difference;
+        }
     </style>
 </head>
-<!-- 
-    The toolkit supports theming from JupyterLab theme
-    For that you need to set `data-jp-theme-name` with a theme _name_
-    and `data-jp-theme-light` with `true` (ligth theme) or `false` (dark theme)
--->
 
-<body data-jp-theme-name="default" data-jp-theme-light="true">
-
+<body data-theme-mode="dark">
     <jp-button appearance="accent" onclick="alert('Accent button pressed')">Click me!</jp-button>
     <jp-button onclick="alert('Neutral button pressed')">Click me!</jp-button>
+    <jp-button id="theme-mode">
+        <span></span>
+    </jp-button>
 
     <script type="module">
-        // Inject JupyterLab theme listener
-        import { addJupyterLabThemeChangeListener } from 'https://unpkg.com/@jupyter/web-components/dist/toolkit.min.js';
-        addJupyterLabThemeChangeListener();
+        // Apply JupyterLab theme
+        import { applyJupyterTheme } from 'https://unpkg.com/@jupyter/web-components/dist/toolkit.min.js';
+
+        function switchThemeMode(th) {
+            const mode = document.body.getAttribute('data-theme-mode');
+            document.body.setAttribute(
+                'data-theme-mode',
+                mode == 'light' ? 'dark' : 'light'
+            );
+            document.body.style.removeProperty('--jp-layout-color1');
+            document.body.style.setProperty(
+                '--jp-layout-color1',
+                // Apparent opposite condition as we don't update the mode variable
+                mode == 'dark' ? '#808080' : 'black'
+            );
+            applyJupyterTheme();
+        }
+        switchThemeMode();
+
+        document.querySelector('#theme-mode').addEventListener('click', () => {
+            switchThemeMode();
+        });
     </script>
 </body>
 

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-export { addJupyterLabThemeChangeListener } from './utilities/theme/applyTheme';
+export {
+  addJupyterLabThemeChangeListener,
+  applyJupyterTheme
+} from './utilities/theme/applyTheme';
 
 export * from './color';
 export * from './design-tokens';

--- a/packages/components/src/utilities/theme/applyTheme.ts
+++ b/packages/components/src/utilities/theme/applyTheme.ts
@@ -174,16 +174,14 @@ const tokenMappings: { [key: string]: IConverter<any> } = {
  * Applies the current Jupyter theme to the toolkit components.
  */
 function applyCurrentTheme() {
-  if (!document.body.getAttribute(THEME_NAME_BODY_ATTRIBUTE)) {
-    return;
-  }
-
   // Get all the styles applied to the <body> tag in the webview HTML
   // Importantly this includes all the CSS variables associated with the
   // current Jupyter theme
   const styles = getComputedStyle(document.body);
 
   // Set mode
+  // If the body attribute is not define, this will be `false` matching
+  // the usual Jupyter behavior of using light theme by default
   const isDark =
     document.body.getAttribute(THEME_MODE_BODY_ATTRIBUTE) === 'false';
   baseLayerLuminance.setValueFor(


### PR DESCRIPTION
In https://github.com/jupyterlab/jupyterlab/pull/15021, styles are not computed for the examples not using the theme manager.