### PR TITLE
Change disabled button style

### DIFF
--- a/packages/components/src/button/button.styles.ts
+++ b/packages/components/src/button/button.styles.ts
@@ -569,6 +569,7 @@ export const buttonStyles: (
     appearanceBehavior(
       'accent',
       css`
+        :host([appearance='accent'][disabled]),
         :host([appearance='accent'][disabled]:hover),
         :host([appearance='accent'][disabled]:active) {
           background: ${accentFillRest};

--- a/packages/components/src/button/button.styles.ts
+++ b/packages/components/src/button/button.styles.ts
@@ -569,7 +569,6 @@ export const buttonStyles: (
     appearanceBehavior(
       'accent',
       css`
-        :host([appearance='accent'][disabled]),
         :host([appearance='accent'][disabled]:hover),
         :host([appearance='accent'][disabled]:active) {
           background: ${accentFillRest};
@@ -661,7 +660,6 @@ export const buttonStyles: (
     appearanceBehavior(
       'stealth',
       css`
-        :host([appearance='stealth'][disabled]),
         :host([appearance='stealth'][disabled]:hover),
         :host([appearance='stealth'][disabled]:active) {
           background: ${neutralFillStealthRest};

--- a/packages/components/src/button/button.styles.ts
+++ b/packages/components/src/button/button.styles.ts
@@ -660,11 +660,6 @@ export const buttonStyles: (
     appearanceBehavior(
       'stealth',
       css`
-        :host([appearance='stealth'][disabled]:hover),
-        :host([appearance='stealth'][disabled]:active) {
-          background: ${neutralFillStealthRest};
-        }
-
         ${StealthButtonStyles}
       `.withBehaviors(
         forcedColorsStylesheetBehavior(css`

--- a/packages/components/src/design-tokens.ts
+++ b/packages/components/src/design-tokens.ts
@@ -10,6 +10,7 @@ import {
   accentForegroundHoverDelta,
   accentForegroundRestDelta,
   ColorRecipe,
+  disabledOpacity,
   fillColor,
   InteractiveColorRecipe,
   InteractiveSwatchSet,
@@ -64,6 +65,7 @@ export {
   designUnit,
   direction,
   DirectionalStyleSheetBehavior,
+  disabledOpacity,
   fillColor,
   focusStrokeInner,
   focusStrokeInnerRecipe,
@@ -173,11 +175,7 @@ export {
 
 const { create } = DesignToken;
 
-/**
- * The default disabled opacity.
- */
-export const disabledOpacity =
-  DesignToken.create<number>('opacity').withDefault(0.4);
+disabledOpacity.withDefault(0.4);
 
 /*
  * The error palette is built using the same color algorithm as the accent palette

--- a/packages/components/src/design-tokens.ts
+++ b/packages/components/src/design-tokens.ts
@@ -64,7 +64,6 @@ export {
   designUnit,
   direction,
   DirectionalStyleSheetBehavior,
-  disabledOpacity,
   fillColor,
   focusStrokeInner,
   focusStrokeInnerRecipe,
@@ -173,6 +172,12 @@ export {
 } from '@microsoft/fast-components';
 
 const { create } = DesignToken;
+
+/**
+ * The default disabled opacity.
+ */
+export const disabledOpacity =
+  DesignToken.create<number>('opacity').withDefault(0.4);
 
 /*
  * The error palette is built using the same color algorithm as the accent palette

--- a/packages/components/src/design-tokens.ts
+++ b/packages/components/src/design-tokens.ts
@@ -175,6 +175,7 @@ export {
 
 const { create } = DesignToken;
 
+// Changing the default to increase contrast
 disabledOpacity.withDefault(0.4);
 
 /*


### PR DESCRIPTION
This PR aims to remove the background on disabled buttons, and to change the disabled opacity to 0.4.

The background is visible only in dark mode, and reduce the contrast of the button content.

See https://github.com/jupyterlab/jupyterlab/pull/15021#discussion_r1378047613 and https://github.com/jupyterlab/jupyterlab/pull/15021#discussion_r1378048138 for context.

