### PR TITLE
Restore force refresh nested status on TreeView

### DIFF
--- a/packages/react-components/lib/TreeView.js
+++ b/packages/react-components/lib/TreeView.js
@@ -17,6 +17,12 @@ export const TreeView = forwardRef((props, forwardedRef) => {
   const { className, renderCollapsedNodes, currentSelected, ...filteredProps } =
     props;
 
+  useLayoutEffect(() => {
+    // Fix using private API to force refresh of nested flag on
+    // first level of tree items.
+    ref.current?.setItems();
+  }, [ref.current]);
+
   /** Properties - run whenever a property has changed */
   useProperties(ref, 'currentSelected', props.currentSelected);
 


### PR DESCRIPTION
Removing this makes first rendering flaky in JLab: https://github.com/jupyterlab/jupyterlab/actions/runs/9953436896